### PR TITLE
Style/RedundantSelf at Tue Oct 23 00:44:55 UTC 2018

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,11 +41,6 @@ Style/Documentation:
     - 'lib/rubocop_challenger/rubocop/todo_reader.rb'
     - 'lib/rubocop_challenger/rubocop/todo_writer.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantSelf:
-  Exclude:
-    - 'lib/rubocop_challenger/rubocop/rule.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/rubocop_challenger/rubocop/rule.rb
+++ b/lib/rubocop_challenger/rubocop/rule.rb
@@ -14,7 +14,7 @@ module RubocopChallenger
       end
 
       def <=>(other)
-        self.offense_count <=> other.offense_count
+        offense_count <=> other.offense_count
       end
 
       def auto_correctable?


### PR DESCRIPTION
Rubocop challenge!
[Style/RedundantSelf](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSelf)

> Redundant `self` detected.

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)

Auto generated by [PR daikou](https://rubygems.org/gems/pr-daikou)
