### PR TITLE
Fix rubocop version mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ jobs:
       - run:
           name: Rubocop Challenge
           command: |
-            gem install -N rubocop_challenger
-            rubocop_challenger go \
+            bundle install
+            bundle exec rubocop_challenger go \
               --email=ryz310@gmail.com \
               --name=ryz310 \
               --template=./lib/templates/checklist.md.erb \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,9 +160,6 @@ workflows:
             branches:
               only:
                 - production
-      - rubocop_challenge:
-          requires:
-            - release
 
   challenge:
     triggers:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ I call such work *Rubocop Challenge*. And the *RubocopChallenger* is a gem to su
 
 ## Usage
 
-### 1. Setting GitHub personal access token
+### 1. Edit your Gemfile
+
+Put this line in your Gemfile.
+
+```rb
+gem 'rubocop_challenger', group: :development, require: false
+```
+
+### 2. Setting GitHub personal access token
 
 GitHub personal access token is required for sending pull requests to your repository.
 
@@ -25,7 +33,7 @@ GitHub personal access token is required for sending pull requests to your repos
 1. Add an environment variable `GITHUB_ACCESS_TOKEN` with your GitHub personal access token
   ![circleci environment variables](images/circleci_environment_variables.png)
 
-### 2. Configure .circleci/config.yml
+### 3. Configure .circleci/config.yml
 
 Configure your `.circleci/config.yml` to run rubocop_challenger, for example:
 
@@ -43,8 +51,8 @@ jobs:
       - run:
           name: Rubocop Challenge
           command: |
-            gem install -N rubocop_challenger
-            rubocop_challenger go \
+            bundle install
+            bundle exec rubocop_challenger go \
               --email=rubocop-challenge@example.com \
               --name="'Rubocop Challenge'"
 


### PR DESCRIPTION
## What's happened

Run `$ gem install -N rubocop_channenger` then it is installed newest rubocop.
In this case `rubocop-0.60.0` was installed.

[<img width="701" alt="circleci" src="https://user-images.githubusercontent.com/3985540/47602346-99405300-da18-11e8-80c4-9fe2fce65bc6.png">](https://circleci.com/gh/ryz310/rubocop_challenger/852)

But in `Gemfile.lock` is still `rubocop-0.59.2`, so it occurs rubocop version mismatch. 

[<img width="1057" alt="continuous_integration_and_deployment" src="https://user-images.githubusercontent.com/3985540/47602356-a2312480-da18-11e8-9de4-432f07d36dd8.png">](https://circleci.com/gh/ryz310/rubocop_challenger/856)


## Solution

Add rubocop_challenger dependency into a Gemfile and then use `bundle exec` on a CircleCI script.