### PR TITLE
Add quiet option on git push command

### DIFF
--- a/lib/rubocop_challenger/git/command.rb
+++ b/lib/rubocop_challenger/git/command.rb
@@ -39,8 +39,14 @@ module RubocopChallenger
         run_with_environments('commit', '-m', "\"#{message}\"")
       end
 
+      # Execute git push command
+      #
+      # @note For security, this command add a quiet option automatically.
+      # @param remote [String] The remote repository name.
+      # @param branch [String] The target branch. default: `#current_branch`
+      # @return [String] The command's standard output.
       def push(remote, branch = current_branch)
-        run('push', remote, branch)
+        run('push', '-q', remote, branch)
       end
 
       def current_sha1

--- a/spec/rubocop_challenger/git/command_spec.rb
+++ b/spec/rubocop_challenger/git/command_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe RubocopChallenger::Git::Command do
         command.push('origin', 'new_branch')
         expect(command)
           .to have_received(:execute)
-          .with('git push origin new_branch')
+          .with('git push -q origin new_branch')
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe RubocopChallenger::Git::Command do
         command.push('origin')
         expect(command)
           .to have_received(:execute)
-          .with('git push origin current_branch')
+          .with('git push -q origin current_branch')
       end
     end
   end


### PR DESCRIPTION
A GitHub access token was revealed by git command output which version 1.8.3.
![_2018-11-26_12_00_37](https://user-images.githubusercontent.com/3985540/48991089-b467c500-f174-11e8-9e5a-deac3b99a076.png)

If we use Git version 2.17.1, it is not done.
![_2018-11-26_12_00_12](https://user-images.githubusercontent.com/3985540/48991088-b467c500-f174-11e8-8cc4-98eba8fd01a7.png)

So it is need a quiet option.
> -q, --quiet
>   Suppress all output, including the listing of updated refs, unless an error occurs. Progress is not reported to the standard error stream.
