### PR TITLE
Fix encountering name error when finding a cop class by cop name

### DIFF
--- a/lib/rubocop_challenger/rubocop/yardoc.rb
+++ b/lib/rubocop_challenger/rubocop/yardoc.rb
@@ -5,7 +5,7 @@ module RubocopChallenger
     # To read YARD style documentation from rubocop gem source code
     class Yardoc
       def initialize(title)
-        @cop_class = Object.const_get("RuboCop::Cop::#{title.sub('/', '::')}")
+        @cop_class = find_cop_class(title)
         YARD.parse(source_file_path)
         @yardoc = YARD::Registry.all(:class).first
         YARD::Registry.clear
@@ -22,6 +22,17 @@ module RubocopChallenger
       private
 
       attr_reader :cop_class, :yardoc
+
+      # Find a RuboCop class by cop name. It find from rubocop/rspec if cannot
+      # find any class from rubocop gem.
+      #
+      # @param cop_name [String] The target cop name
+      # @return [Class] Found RuboCop class
+      def find_cop_class(cop_name)
+        Object.const_get("RuboCop::Cop::#{cop_name.sub('/', '::')}")
+      rescue NameError
+        Object.const_get("RuboCop::Cop::RSpec::#{cop_name.sub('/', '::')}")
+      end
 
       def instance_methods
         [

--- a/spec/rubocop_challenger/rubocop/yardoc_spec.rb
+++ b/spec/rubocop_challenger/rubocop/yardoc_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe RubocopChallenger::Rubocop::Yardoc do
   let(:yardoc) { described_class.new(title) }
   let(:title) { 'Style/Alias' }
 
+  describe '#initialize' do
+    let(:title) { 'Capybara/CurrentPathExpectation' }
+
+    it 'find from rubocop/rspec if cannot find a class from rubocop gem' do
+      expect { yardoc }.not_to raise_error
+    end
+  end
+
   describe '#description' do
     let(:docstring) { <<~DOCSTRING.chomp }
       This cop enforces the use of either `#alias` or `#alias_method`


### PR DESCRIPTION
Encountered NameError when running Rubocop Challenger on the circle ci.

![2019-01-17 12 02 11](https://user-images.githubusercontent.com/3985540/51292873-bdc42e00-1a4f-11e9-8f08-4d9bd598d61a.png)

As a result of the investigation, I found that cop naming rule was cause on the rubocop/rspec.

Normal case, cop names which written in .rubocop_todo.yml are class name suffix, which prefix is "RuboCop::Cop". However, in some case these are not the case. 
For example, "Capybara/CurrentPathExpectation" is it. 

It need special logic which retry finding under "rubocop/cop/rspec" directory.