### PR TITLE
Fix exit code when no more auto-correctable rule

### DIFF
--- a/lib/rubocop_challenger/cli.rb
+++ b/lib/rubocop_challenger/cli.rb
@@ -49,7 +49,6 @@ module RubocopChallenger
       Go.new(options).exec
     rescue Errors::NoAutoCorrectableRule => e
       color_puts e.message, CommandLine::YELLOW
-      exit_process!
     rescue StandardError => e
       color_puts e.message, CommandLine::RED
       exit_process!

--- a/spec/rubocop_challenger/cli_spec.rb
+++ b/spec/rubocop_challenger/cli_spec.rb
@@ -65,8 +65,12 @@ RSpec.describe RubocopChallenger::CLI do
         go
         expect(cli)
           .to have_received(:color_puts)
-          .with('There is no auto-correctable rule', 33).ordered
-        expect(cli).to have_received(:exit_process!).ordered
+          .with('There is no auto-correctable rule', 33)
+      end
+
+      it 'does not return exit code 1' do
+        go
+        expect(cli).not_to have_received(:exit_process!)
       end
     end
   end


### PR DESCRIPTION
<img width="1284" alt="2019-02-25 17 03 35" src="https://user-images.githubusercontent.com/3985540/53322669-699a4c80-391f-11e9-9cb2-69c08d7f326e.png">
