### PR TITLE
Farewell ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,6 @@ references:
           destination: yardoc
 
 jobs:
-  build_on_ruby_2.3:
-    docker:
-       - image: circleci/ruby:2.3-node-browsers
-    <<: *build
   build_on_ruby_2.4:
     docker:
        - image: circleci/ruby:2.4-node-browsers
@@ -104,15 +100,15 @@ jobs:
     <<: *build
   rubocop:
     docker:
-       - image: circleci/ruby:2.3-node-browsers
+       - image: circleci/ruby:2.4-node-browsers
     <<: *rubocop
   yardoc:
     docker:
-       - image: circleci/ruby:2.3-node-browsers
+       - image: circleci/ruby:2.4-node-browsers
     <<: *yardoc
   verify_rubocop_challenge:
     docker:
-      - image: circleci/ruby:2.3-node-browsers
+      - image: circleci/ruby:2.4-node-browsers
     working_directory: ~/repo
     steps:
       - checkout
@@ -139,7 +135,7 @@ jobs:
 
   rubocop_challenge:
     docker:
-      - image: circleci/ruby:2.3-node-browsers
+      - image: circleci/ruby:2.4-node-browsers
     working_directory: ~/repo
     steps:
       - checkout
@@ -155,7 +151,7 @@ jobs:
 
   release:
     docker:
-       - image: circleci/ruby:2.3-node-browsers
+       - image: circleci/ruby:2.4-node-browsers
     working_directory: ~/repo
     steps:
       - checkout
@@ -179,7 +175,6 @@ workflows:
 
   commit:
     jobs:
-      - build_on_ruby_2.3
       - build_on_ruby_2.4
       - build_on_ruby_2.5
       - build_on_ruby_2.6
@@ -190,7 +185,6 @@ workflows:
       - release:
           context: RubyGems API Key
           requires:
-            - build_on_ruby_2.3
             - build_on_ruby_2.4
             - build_on_ruby_2.5
             - build_on_ruby_2.6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ Run `$ rubocop --auto-correct` and create PR to GitHub repo
 
 ## Requirement
 
-* Ruby 2.3 or higher
-    * NOTE: Ruby 2.3 will EOL soon (See: [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/))
+* Ruby 2.4 or higher
 
 ## Development
 


### PR DESCRIPTION
Ruby 2.3 will EOL at 2019-03-31

See: [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/)