### PR TITLE
Fix the version of pr_comet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop_challenger (2.0.0.pre3)
-      pr_comet
+      pr_comet (~> 0.1.0)
       rubocop
       rubocop-rspec
       thor

--- a/challenger.gemspec
+++ b/challenger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'pr_comet'
+  spec.add_runtime_dependency 'pr_comet', '~> 0.1.0'
   spec.add_runtime_dependency 'rubocop'
   spec.add_runtime_dependency 'rubocop-rspec'
   spec.add_runtime_dependency 'thor'


### PR DESCRIPTION
Following error has occurred with pr_comet v0.2.0.

![スクリーンショット 2019-06-10 11 53 10](https://user-images.githubusercontent.com/3985540/59169737-6ba6b500-8b76-11e9-9bf1-dded2e93d4da.png)

It is caused that pr_comet has been using rainbow gem since ryz310/pr_comet#16 and delete constant PrComet::CommandLine::YELLOW and so on.

This PR fix the version of pr_comet as workaround.
In the future, I will eliminate depending on pr_comet constant.