### PR TITLE
Use rainbow gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'challenger.gemspec'
     - 'spec/**/*'
 
 # For integration testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rubocop_challenger (2.0.0.pre4)
       pr_comet (~> 0.1.0)
+      rainbow
       rubocop
       rubocop-rspec
       thor

--- a/challenger.gemspec
+++ b/challenger.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'pr_comet', '~> 0.1.0'
+  spec.add_runtime_dependency 'pr_comet', '~> 0.2.0'
   spec.add_runtime_dependency 'rainbow'
   spec.add_runtime_dependency 'rubocop'
   spec.add_runtime_dependency 'rubocop-rspec'

--- a/challenger.gemspec
+++ b/challenger.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'pr_comet', '~> 0.1.0'
+  spec.add_runtime_dependency 'rainbow'
   spec.add_runtime_dependency 'rubocop'
   spec.add_runtime_dependency 'rubocop-rspec'
   spec.add_runtime_dependency 'thor'

--- a/lib/rubocop_challenger.rb
+++ b/lib/rubocop_challenger.rb
@@ -2,6 +2,7 @@
 
 require 'erb'
 require 'yard'
+require 'rainbow'
 require 'pr_comet'
 require 'rubocop'
 require 'rubocop-rspec'

--- a/lib/rubocop_challenger/cli.rb
+++ b/lib/rubocop_challenger/cli.rb
@@ -5,8 +5,6 @@ require 'thor'
 module RubocopChallenger
   # To define CLI commands
   class CLI < Thor
-    include PrComet::CommandLine
-
     desc 'go', 'Run `$ rubocop --auto-correct` and create a PR to GitHub repo'
     option :email,
            required: true,
@@ -44,9 +42,9 @@ module RubocopChallenger
     def go
       Go.new(options).exec
     rescue Errors::NoAutoCorrectableRule => e
-      color_puts e.message, PrComet::CommandLine::YELLOW
+      puts Rainbow(e.message).yellow
     rescue StandardError => e
-      color_puts e.message, PrComet::CommandLine::RED
+      puts Rainbow(e.message).red
       exit_process!
     end
 

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -3,8 +3,6 @@
 module RubocopChallenger
   # Executes Rubocop Challenge flow
   class Go
-    include PrComet::CommandLine
-
     # @param options [Hash] describe_options_here
     def initialize(options)
       @options = options
@@ -126,8 +124,7 @@ module RubocopChallenger
         config_editor.add_ignore(rule)
         config_editor.save
       end
-      color_puts DESCRIPTION_THAT_CHALLENGE_IS_INCOMPLETE,
-                 PrComet::CommandLine::YELLOW
+      puts Rainbow(DESCRIPTION_THAT_CHALLENGE_IS_INCOMPLETE).yellow
     end
 
     # Checks the challenge result. If the challenge is successed, the rule

--- a/spec/rubocop_challenger/cli_spec.rb
+++ b/spec/rubocop_challenger/cli_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe RubocopChallenger::CLI do
 
   before do
     allow(cli).to receive(:options).and_return(options)
-    allow(cli).to receive(:color_puts)
     allow(cli).to receive(:exit_process!)
   end
 
@@ -45,11 +44,8 @@ RSpec.describe RubocopChallenger::CLI do
       end
 
       it 'outputs a error message and exit process' do
-        go
-        expect(cli)
-          .to have_received(:color_puts)
-          .with('Error message', 31).ordered
-        expect(cli).to have_received(:exit_process!).ordered
+        expect { go }.to output("\e[31mError message\e[0m\n").to_stdout
+        expect(cli).to have_received(:exit_process!)
       end
     end
 
@@ -61,10 +57,8 @@ RSpec.describe RubocopChallenger::CLI do
       end
 
       it 'outputs a description and exit process' do
-        go
-        expect(cli)
-          .to have_received(:color_puts)
-          .with('There is no auto-correctable rule', 33)
+        expect { go }
+          .to output("\e[33mThere is no auto-correctable rule\e[0m\n").to_stdout
       end
 
       it 'does not return exit code 1' do


### PR DESCRIPTION
In #212, following problem occurred.
So this PR eliminates dependencies on pr_comet constant.
closes #195

> Following error has occurred with pr_comet v0.2.0.
> 
> ![スクリーンショット 2019-06-10 11 53 10](https://user-images.githubusercontent.com/3985540/59169737-6ba6b500-8b76-11e9-9bf1-dded2e93d4da.png)
> 
> It is caused that pr_comet has been using rainbow gem since [ryz310/pr_comet#16](https://github.com/ryz310/pr_comet/pull/16) and delete constant PrComet::CommandLine::YELLOW and so on.
> 
> This PR fix the version of pr_comet as workaround.
> In the future, I will eliminate depending on pr_comet constant.

