### PR TITLE
Support auto gem config options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop_challenger (2.0.0.pre4)
-      pr_comet (~> 0.1.0)
+      pr_comet (~> 0.2.0)
       rainbow
       rubocop
       rubocop-rspec
@@ -30,8 +30,9 @@ GEM
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
-    pr_comet (0.1.1)
+    pr_comet (0.2.0)
       octokit
+      rainbow
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/README.md
+++ b/README.md
@@ -109,16 +109,19 @@ Usage:
   rubocop_challenger go --email=EMAIL --name=NAME
 
 Options:
-      --email=EMAIL            # The Pull Request committer email
-      --name=NAME              # The Pull Request committer name
-  f, [--file-path=FILE_PATH]   # Set your ".rubocop_todo.yml" path
-                               # Default: .rubocop_todo.yml
-  t, [--template=TEMPLATE]     # A Pull Request template `erb` file path.You can use variable that `title`, `rubydoc_url`, `description` and `examples` into the erb file.
-      [--mode=MODE]            # Mode to select deletion target. You can choice "most_occurrence", "least_occurrence", or "random"
-                               # Default: most_occurrence
-  l, [--labels=one two three]  # Label to give to Pull Request
-                               # Default: ["rubocop challenge"]
-      [--no-create-pr]         # No create a pull request (for testing)
+      --email=EMAIL                                      # The Pull Request committer email
+      --name=NAME                                        # The Pull Request committer name
+  f, [--file-path=FILE_PATH]                             # Set your ".rubocop_todo.yml" path
+                                                         # Default: .rubocop_todo.yml
+  t, [--template=TEMPLATE]                               # A Pull Request template `erb` file path.You can use variable that `title`, `rubydoc_url`, `description` and `examples` into the erb file.
+      [--mode=MODE]                                      # Mode to select deletion target. You can choice "most_occurrence", "least_occurrence", or "random"
+                                                         # Default: most_occurrence
+  l, [--labels=one two three]                            # Label to give to Pull Request
+                                                         # Default: ["rubocop challenge"]
+      [--no-create-pr]                                   # No create a pull request (for testing)
+      [--exclude-limit=N]                                # For how many exclude properties when creating the .rubocop_todo.yml
+      [--auto-gen-timestamp], [--no-auto-gen-timestamp]  # Include the date and time when creating the .rubocop_todo.yml
+                                                         # Default: true
 
 Run `$ rubocop --auto-correct` and create a PR to GitHub repo
 ```

--- a/lib/rubocop_challenger/cli.rb
+++ b/lib/rubocop_challenger/cli.rb
@@ -39,6 +39,14 @@ module RubocopChallenger
            type: :boolean,
            default: false,
            desc: 'No create a pull request (for testing)'
+    option :'exclude-limit',
+           type: :numeric,
+           desc: 'For how many exclude properties when creating the ' \
+                 '.rubocop_todo.yml'
+    option :'auto-gen-timestamp',
+           type: :boolean,
+           default: true,
+           desc: 'Include the date and time when creating the .rubocop_todo.yml'
     def go
       Go.new(options).exec
     rescue Errors::NoAutoCorrectableRule => e

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -6,6 +6,8 @@ module RubocopChallenger
     # @param options [Hash] describe_options_here
     def initialize(options)
       @options = options
+      @exclude_limit = options[:'exclude-limit']
+      @auto_gen_timestamp = options[:'auto-gen-timestamp']
       @pull_request = PullRequest.new(
         options[:name],
         options[:email],
@@ -29,7 +31,7 @@ module RubocopChallenger
 
     private
 
-    attr_reader :options, :pull_request
+    attr_reader :options, :pull_request, :exclude_limit, :auto_gen_timestamp
 
     def update_rubocop!
       bundler = Bundler::Command.new
@@ -47,7 +49,10 @@ module RubocopChallenger
     def regenerate_rubocop_todo!
       before_version = scan_rubocop_version_in_rubocop_todo_file
       pull_request.commit! ':police_car: regenerate rubocop todo' do
-        Rubocop::Command.new.auto_gen_config
+        Rubocop::Command.new.auto_gen_config(
+          exclude_limit: exclude_limit,
+          auto_gen_timestamp: auto_gen_timestamp
+        )
       end
       after_version = scan_rubocop_version_in_rubocop_todo_file
 

--- a/lib/rubocop_challenger/rubocop/command.rb
+++ b/lib/rubocop_challenger/rubocop/command.rb
@@ -10,8 +10,11 @@ module RubocopChallenger
         run('--auto-correct')
       end
 
-      def auto_gen_config
-        run('--auto-gen-config')
+      def auto_gen_config(exclude_limit: nil, auto_gen_timestamp: true)
+        commands = ['--auto-gen-config']
+        commands << "--exclude-limit #{exclude_limit}" if exclude_limit
+        commands << '--no-auto-gen-timestamp' unless auto_gen_timestamp
+        run(*commands)
       end
 
       private

--- a/spec/rubocop_challenger/cli_spec.rb
+++ b/spec/rubocop_challenger/cli_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe RubocopChallenger::CLI do
       file_path: '.rubocop_todo.yml',
       mode: 'most_occurrence',
       labels: ['rubocop challenge'],
-      'no-create-pr': false
+      'no-create-pr': false,
+      'exclude-limit': 99,
+      'no-auto-gen-timestamp': true
     }
   end
 

--- a/spec/rubocop_challenger/go_spec.rb
+++ b/spec/rubocop_challenger/go_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe RubocopChallenger::Go do
       mode: 'most_occurrence',
       labels: ['rubocop challenge'],
       template: 'template_file_path',
-      'no-create-pr': false
+      'no-create-pr': false,
+      'auto-gen-timestamp': false,
+      'exclude-limit': 99
     )
   end
 
@@ -96,7 +98,8 @@ RSpec.describe RubocopChallenger::Go do
       it do
         exec
         expect(rubocop_command)
-          .to have_received(:auto_gen_config).with(no_args).twice
+          .to have_received(:auto_gen_config)
+          .with(exclude_limit: 99, auto_gen_timestamp: false).twice
       end
 
       it do
@@ -154,7 +157,8 @@ RSpec.describe RubocopChallenger::Go do
         it do
           safe_exec.call
           expect(rubocop_command)
-            .to have_received(:auto_gen_config).with(no_args).once
+            .to have_received(:auto_gen_config)
+            .with(exclude_limit: 99, auto_gen_timestamp: false).once
         end
 
         it do

--- a/spec/rubocop_challenger/rubocop/command_spec.rb
+++ b/spec/rubocop_challenger/rubocop/command_spec.rb
@@ -17,11 +17,37 @@ RSpec.describe RubocopChallenger::Rubocop::Command do
   end
 
   describe '#auto_gen_config' do
-    it do
-      command.auto_gen_config
-      expect(command)
-        .to have_received(:execute)
-        .with('bundle exec rubocop --auto-gen-config || true')
+    context 'without any options' do
+      let(:expected) do
+        'bundle exec rubocop --auto-gen-config || true'
+      end
+
+      it do
+        command.auto_gen_config
+        expect(command).to have_received(:execute).with(expected)
+      end
+    end
+
+    context 'with exclude_limit option' do
+      let(:expected) do
+        'bundle exec rubocop --auto-gen-config --exclude-limit 10 || true'
+      end
+
+      it do
+        command.auto_gen_config(exclude_limit: 10)
+        expect(command).to have_received(:execute).with(expected)
+      end
+    end
+
+    context 'with auto_gen_timestamp option' do
+      let(:expected) do
+        'bundle exec rubocop --auto-gen-config --no-auto-gen-timestamp || true'
+      end
+
+      it do
+        command.auto_gen_config(auto_gen_timestamp: false)
+        expect(command).to have_received(:execute).with(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
close #215 

Support following options for `--auto-gen-config`.

* `--exclude-limit`
* `--no-auto-gen-timestamp`

**Usage**

```sh
$ rubocop_challenger go \
     --email=ryz310@gmail.com \
     --name=ryz310 \
     --exclude-limit 99999 \
     --no-auto-gen-timestamp
```