### PR TITLE
Add pull request to GitHub project on execute

### DIFF
--- a/lib/rubocop_challenger/cli.rb
+++ b/lib/rubocop_challenger/cli.rb
@@ -35,6 +35,15 @@ module RubocopChallenger
            default: ['rubocop challenge'],
            aliases: :l,
            desc: 'Label to give to Pull Request'
+    option :project_column_name,
+           type: :string,
+           desc: 'A project column name. You can add the created PR to the ' \
+                 'GitHub project'
+    option :project_id,
+           type: :numeric,
+           desc: 'A target project ID. If does not supplied, this method ' \
+                 'will find a project which associated the repository. When ' \
+                 'the repository has multiple projects, you should supply this.'
     option :'no-create-pr',
            type: :boolean,
            default: false,

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -61,6 +61,7 @@ module RubocopChallenger
         project_id: options[:project_id]
       }
     end
+
     def update_rubocop!
       bundler = Bundler::Command.new
       pull_request.commit! ':police_car: $ bundle update rubocop' do

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -3,17 +3,31 @@
 module RubocopChallenger
   # Executes Rubocop Challenge flow
   class Go
-    # @param options [Hash] describe_options_here
+    # @param options [Hash]
+    #   Options for the rubocop challenge
+    # @option exclude-limit [Integer]
+    #   For how many exclude properties when creating the ".rubocop_todo.yml"
+    # @option auto-gen-timestamp [Boolean]
+    #   Include the date and time when creating the ".rubocop_todo.yml"
+    # @option name [String]
+    #   The author name which use at the git commit
+    # @option email [String]
+    #   The email address which use at the git commit
+    # @option labels [Array<String>]
+    #   Will create a pull request with the labels
+    # @option no-create-pr [Boolean]
+    #   Does not create a pull request when given `true`
+    # @option project_column_name [String]
+    #   A project column name. You can add the created PR to the GitHub project
+    # @option project_id [Integer]
+    #   A target project ID. If does not supplied, this method will find a
+    #   project which associated the repository. When the repository has
+    #   multiple projects, you should supply this.
     def initialize(options)
       @options = options
       @exclude_limit = options[:'exclude-limit']
       @auto_gen_timestamp = options[:'auto-gen-timestamp']
-      @pull_request = PullRequest.new(
-        options[:name],
-        options[:email],
-        options[:labels],
-        options[:'no-create-pr']
-      )
+      @pull_request = PullRequest.new(extract_pull_request_options(options))
     end
 
     # Executes Rubocop Challenge flow
@@ -33,6 +47,20 @@ module RubocopChallenger
 
     attr_reader :options, :pull_request, :exclude_limit, :auto_gen_timestamp
 
+    # Extracts options for the PullRequest class
+    #
+    # @param options [Hash] The target options
+    # @return [Hash] Options for the PullRequest class
+    def extract_pull_request_options(options)
+      {
+        user_name: options[:name],
+        user_email: options[:email],
+        labels: options[:labels],
+        dry_run: options[:'no-create-pr'],
+        project_column_name: options[:project_column_name],
+        project_id: options[:project_id]
+      }
+    end
     def update_rubocop!
       bundler = Bundler::Command.new
       pull_request.commit! ':police_car: $ bundle update rubocop' do

--- a/lib/rubocop_challenger/pull_request.rb
+++ b/lib/rubocop_challenger/pull_request.rb
@@ -19,7 +19,7 @@ module RubocopChallenger
     #   A target project ID. If does not supplied, this method will find a
     #   project which associated the repository. When the repository has
     #   multiple projects, you should supply this.
-    def initialize(user_name, user_email, options = {})
+    def initialize(user_name, user_email, **options)
       @pr_comet = PrComet.new(
         base: 'master',
         branch: "rubocop-challenge/#{timestamp}",

--- a/lib/rubocop_challenger/pull_request.rb
+++ b/lib/rubocop_challenger/pull_request.rb
@@ -19,7 +19,7 @@ module RubocopChallenger
     #   A target project ID. If does not supplied, this method will find a
     #   project which associated the repository. When the repository has
     #   multiple projects, you should supply this.
-    def initialize(user_name, user_email, **options)
+    def initialize(user_name:, user_email:, **options)
       @pr_comet = PrComet.new(
         base: 'master',
         branch: "rubocop-challenge/#{timestamp}",

--- a/lib/rubocop_challenger/pull_request.rb
+++ b/lib/rubocop_challenger/pull_request.rb
@@ -7,19 +7,29 @@ module RubocopChallenger
     #   The author name which use at the git commit
     # @param user_email [String]
     #   The email address which use at the git commit
-    # @param labels [Array<String>]
+    # @param options [Hash]
+    #   Optional parameters
+    # @option labels [Array<String>]
     #   Will create a pull request with the labels
-    # @param dry_run [Boolean]
+    # @option dry_run [Boolean]
     #   Does not create a pull request when given `true`
-    def initialize(user_name, user_email, labels, dry_run = false)
+    # @option project_column_name [String]
+    #   A project column name. You can add the created PR to the GitHub project
+    # @option project_id [Integer]
+    #   A target project ID. If does not supplied, this method will find a
+    #   project which associated the repository. When the repository has
+    #   multiple projects, you should supply this.
+    def initialize(user_name, user_email, options = {})
       @pr_comet = PrComet.new(
         base: 'master',
         branch: "rubocop-challenge/#{timestamp}",
         user_name: user_name,
         user_email: user_email
       )
-      @labels = labels
-      @dry_run = dry_run
+      @labels = options[:labels]
+      @dry_run = options[:dry_run]
+      @project_column_name = options[:project_column_name]
+      @project_id = options[:project_id]
     end
 
     # Add and commit local files to the pull request
@@ -42,8 +52,7 @@ module RubocopChallenger
     def create_rubocop_challenge_pr!(rule, template_file_path = nil)
       create_pull_request!(
         title: "#{rule.title}-#{timestamp}",
-        body: Github::PrTemplate.new(rule, template_file_path).generate,
-        labels: labels
+        body: Github::PrTemplate.new(rule, template_file_path).generate
       )
     end
 
@@ -61,18 +70,25 @@ module RubocopChallenger
     def create_regenerate_todo_pr!(before_version, after_version)
       create_pull_request!(
         title: "Re-generate .rubocop_todo.yml with RuboCop v#{after_version}",
-        body: generate_pull_request_body(before_version, after_version),
-        labels: labels
+        body: generate_pull_request_body(before_version, after_version)
       )
     end
 
     private
 
-    attr_reader :pr_comet, :labels, :dry_run
+    attr_reader :pr_comet, :labels, :dry_run, :project_column_name, :project_id
 
     # Create a PR with description of what modification were made.
+    #
+    # @params pr_comet_options [Hash]
     def create_pull_request!(pr_comet_options)
-      pr_comet.create!(pr_comet_options) unless dry_run
+      options = {
+        labels: labels,
+        project_column_name: project_column_name,
+        project_id: project_id
+      }.merge(pr_comet_options)
+
+      pr_comet.create!(options) unless dry_run
     end
 
     # @param before_version [String]

--- a/lib/rubocop_challenger/rubocop/command.rb
+++ b/lib/rubocop_challenger/rubocop/command.rb
@@ -6,10 +6,15 @@ module RubocopChallenger
     class Command
       include PrComet::CommandLine
 
+      # Executes auto correction
       def auto_correct
         run('--auto-correct')
       end
 
+      # Generates `.rubocop_todo.yml`
+      #
+      # @param exclude_limit [Integer] default: nil
+      # @param auto_gen_timestamp [Boolean] default: true
       def auto_gen_config(exclude_limit: nil, auto_gen_timestamp: true)
         commands = ['--auto-gen-config']
         commands << "--exclude-limit #{exclude_limit}" if exclude_limit

--- a/spec/rubocop_challenger/cli_spec.rb
+++ b/spec/rubocop_challenger/cli_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe RubocopChallenger::CLI do
       file_path: '.rubocop_todo.yml',
       mode: 'most_occurrence',
       labels: ['rubocop challenge'],
+      project_column_name: 'Column 1',
+      project_id: 123_456_789,
       'no-create-pr': false,
       'exclude-limit': 99,
       'no-auto-gen-timestamp': true

--- a/spec/rubocop_challenger/go_spec.rb
+++ b/spec/rubocop_challenger/go_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe RubocopChallenger::Go do
       mode: 'most_occurrence',
       labels: ['rubocop challenge'],
       template: 'template_file_path',
+      project_column_name: 'Column 1',
+      project_id: 123_456_789,
       'no-create-pr': false,
       'auto-gen-timestamp': false,
       'exclude-limit': 99
@@ -80,12 +82,21 @@ RSpec.describe RubocopChallenger::Go do
     end
 
     shared_examples 'build PullRequest instance with the options' do
+      let(:expected_options) do
+        {
+          user_name: 'Rubocop Challenger',
+          user_email: 'rubocop-challenger@example.com',
+          labels: ['rubocop challenge'],
+          dry_run: false,
+          project_column_name: 'Column 1',
+          project_id: 123_456_789
+        }
+      end
+
       it do
         safe_exec.call
-        expect(RubocopChallenger::PullRequest).to have_received(:new).with(
-          'Rubocop Challenger', 'rubocop-challenger@example.com',
-          ['rubocop challenge'], false
-        )
+        expect(RubocopChallenger::PullRequest)
+          .to have_received(:new).with(expected_options)
       end
     end
 

--- a/spec/rubocop_challenger/pull_request_spec.rb
+++ b/spec/rubocop_challenger/pull_request_spec.rb
@@ -4,11 +4,21 @@ require 'spec_helper'
 
 RSpec.describe RubocopChallenger::PullRequest do
   let(:pull_request) do
-    described_class.new('user_name', 'user_email', labels, dry_run)
+    described_class.new('user_name', 'user_email', options)
   end
 
+  let(:options) do
+    {
+      labels: labels,
+      dry_run: dry_run,
+      project_column_name: project_column_name,
+      project_id: project_id
+    }
+  end
   let(:labels) { ['label-1', 'label-2'] }
   let(:dry_run) { false }
+  let(:project_column_name) { 'Column 1' }
+  let(:project_id) { 123_456_789 }
   let(:pr_comet) { instance_double(PrComet, commit: nil, create!: nil) }
 
   before do
@@ -67,7 +77,11 @@ RSpec.describe RubocopChallenger::PullRequest do
       it do
         create_pull_request!
         expect(pr_comet).to have_received(:create!).with(
-          title: 'title-20181112212509', body: 'body', labels: labels
+          title: 'title-20181112212509',
+          body: 'body',
+          labels: labels,
+          project_column_name: project_column_name,
+          project_id: project_id
         )
       end
     end
@@ -92,7 +106,9 @@ RSpec.describe RubocopChallenger::PullRequest do
         {
           title: 'Re-generate .rubocop_todo.yml with RuboCop v0.65.0',
           body: expected_pr_body,
-          labels: labels
+          labels: labels,
+          project_column_name: project_column_name,
+          project_id: project_id
         }
       end
 

--- a/spec/rubocop_challenger/pull_request_spec.rb
+++ b/spec/rubocop_challenger/pull_request_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe RubocopChallenger::PullRequest do
     end
 
     context 'when dry_run is false' do
+      let(:expected_options) do
+        {
+          title: 'title-20181112212509',
+          body: 'body',
+          labels: labels,
+          project_column_name: project_column_name,
+          project_id: project_id
+        }
+      end
+
       it do
         create_pull_request!
         expect(RubocopChallenger::Github::PrTemplate)
@@ -76,13 +86,7 @@ RSpec.describe RubocopChallenger::PullRequest do
 
       it do
         create_pull_request!
-        expect(pr_comet).to have_received(:create!).with(
-          title: 'title-20181112212509',
-          body: 'body',
-          labels: labels,
-          project_column_name: project_column_name,
-          project_id: project_id
-        )
+        expect(pr_comet).to have_received(:create!).with(expected_options)
       end
     end
   end

--- a/spec/rubocop_challenger/pull_request_spec.rb
+++ b/spec/rubocop_challenger/pull_request_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe RubocopChallenger::PullRequest do
-  let(:pull_request) do
-    described_class.new('user_name', 'user_email', options)
-  end
-
+  let(:pull_request) { described_class.new(options) }
   let(:options) do
     {
+      user_name: 'user_name',
+      user_email: 'user_email',
       labels: labels,
       dry_run: dry_run,
       project_column_name: project_column_name,


### PR DESCRIPTION
Introduce the pr_comet new feature (ryz310/pr_comet#18) which adds pull request to GitHub project on execute. 