### PR TITLE
Fix/load error of the updated gems

### DIFF
--- a/lib/rubocop_challenger.rb
+++ b/lib/rubocop_challenger.rb
@@ -4,7 +4,6 @@ require 'erb'
 require 'yard'
 require 'rainbow'
 require 'pr_comet'
-require 'rubocop'
 require 'rubocop_challenger/errors'
 require 'rubocop_challenger/version'
 require 'rubocop_challenger/rubocop/rule'
@@ -20,11 +19,11 @@ require 'rubocop_challenger/cli'
 require 'rubocop_challenger/bundler/command'
 require 'rubocop_challenger/github/pr_template'
 
-# Loads gems for feature of integrations
-%w[rubocop-performance rubocop-rails rubocop-rspec].each do |dependency|
-  begin
-    require dependency
-  rescue LoadError
-    nil
-  end
+module RubocopChallenger
+  RSPEC_GEMS = %w[
+    rubocop
+    rubocop-performance
+    rubocop-rails
+    rubocop-rspec
+  ].freeze
 end

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -67,10 +67,7 @@ module RubocopChallenger
     def update_rubocop!
       bundler = Bundler::Command.new
       pull_request.commit! ':police_car: $ bundle update rubocop' do
-        bundler.update 'rubocop',
-                       'rubocop-performance',
-                       'rubocop-rails',
-                       'rubocop-rspec'
+        bundler.update(*RSPEC_GEMS)
       end
     end
 

--- a/lib/rubocop_challenger/rubocop/yardoc.rb
+++ b/lib/rubocop_challenger/rubocop/yardoc.rb
@@ -24,6 +24,7 @@ module RubocopChallenger
 
       attr_reader :cop_class, :yardoc
 
+      # Loads gems for YARDoc creation
       def load_rspec_gems!
         RSPEC_GEMS.each do |dependency|
           begin

--- a/lib/rubocop_challenger/rubocop/yardoc.rb
+++ b/lib/rubocop_challenger/rubocop/yardoc.rb
@@ -5,6 +5,7 @@ module RubocopChallenger
     # To read YARD style documentation from rubocop gem source code
     class Yardoc
       def initialize(title)
+        load_rspec_gems!
         @cop_class = find_cop_class(title)
         YARD.parse(source_file_path)
         @yardoc = YARD::Registry.all(:class).first
@@ -22,6 +23,16 @@ module RubocopChallenger
       private
 
       attr_reader :cop_class, :yardoc
+
+      def load_rspec_gems!
+        RSPEC_GEMS.each do |dependency|
+          begin
+            require dependency
+          rescue LoadError
+            nil
+          end
+        end
+      end
 
       # Find a RuboCop class by cop name. It find from rubocop/rspec if cannot
       # find any class from rubocop gem.


### PR DESCRIPTION
## Why?

fixes #237 

An error occurred when rubocop-rails gem updated and then YARDoc creation. Because the updated gem source code has not been loaded the Rucobop-Challenger process.

## How?

Change the RuboCop gems loading timings from the start of the process to just before YARDoc creation. There is no problem because there is no dependency on other processes.