### PR TITLE
Fix keyword argument expanding for Ruby 3.0

### DIFF
--- a/lib/rubocop_challenger/pull_request.rb
+++ b/lib/rubocop_challenger/pull_request.rb
@@ -90,7 +90,7 @@ module RubocopChallenger
         project_id: project_id
       }.merge(pr_comet_options)
 
-      pr_comet.create!(options) unless dry_run
+      pr_comet.create!(**options) unless dry_run
     end
 
     # @param before_version [String]

--- a/spec/lib/rubocop_challenger/pull_request_spec.rb
+++ b/spec/lib/rubocop_challenger/pull_request_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RubocopChallenger::PullRequest do
 
       it do
         create_pull_request!
-        expect(pr_comet).to have_received(:create!).with(expected_options)
+        expect(pr_comet).to have_received(:create!).with(**expected_options)
       end
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe RubocopChallenger::PullRequest do
 
       it do
         create_pull_request!
-        expect(pr_comet).to have_received(:create!).with(expected_options)
+        expect(pr_comet).to have_received(:create!).with(**expected_options)
       end
     end
   end


### PR DESCRIPTION
Fix it: https://app.circleci.com/pipelines/github/ryz310/my_api_client/1287/workflows/115482c9-2eaa-485b-972d-3b9f85f071ae/jobs/20671

![スクリーンショット 2021-01-06 12 15 52](https://user-images.githubusercontent.com/3985540/103724970-ed8fe600-5018-11eb-8448-dacf434885ed.png)
