### PR TITLE
Modify the description of whether it is safe auto-correct

### DIFF
--- a/lib/templates/checklist.md.erb
+++ b/lib/templates/checklist.md.erb
@@ -3,10 +3,10 @@
 [<%= title %>](<%= rubydoc_url %>)
 
 <% if safe_autocorrect? -%>
-**Safe autocorrect: true**
+**Safe autocorrect: Yes**
 :white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
 <% else -%>
-**Safe autocorrect: false**
+**Safe autocorrect: No**
 :warning: The auto-correct a cop can yield false positives by design.
 <% end -%>
 

--- a/lib/templates/default.md.erb
+++ b/lib/templates/default.md.erb
@@ -3,10 +3,10 @@
 [<%= title %>](<%= rubydoc_url %>)
 
 <% if safe_autocorrect? -%>
-**Safe autocorrect: true**
+**Safe autocorrect: Yes**
 :white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
 <% else -%>
-**Safe autocorrect: false**
+**Safe autocorrect: No**
 :warning: The auto-correct a cop can yield false positives by design.
 <% end -%>
 

--- a/spec/lib/rubocop_challenger/github/pr_template_spec.rb
+++ b/spec/lib/rubocop_challenger/github/pr_template_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubocopChallenger::Github::PrTemplate do
 
         [Style/Alias](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Alias)
 
-        **Safe autocorrect: true**
+        **Safe autocorrect: Yes**
         :white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
 
         ## Description


### PR DESCRIPTION
I think something wrong with currently PR description that whether it's safe auto-correct. 
It should be yes/no rather than true/false.