### PR TITLE
Fix wrong usage of `Array#reject!`: this might return nil

### DIFF
--- a/lib/rubocop_challenger/rubocop/todo_reader.rb
+++ b/lib/rubocop_challenger/rubocop/todo_reader.rb
@@ -23,7 +23,7 @@ module RubocopChallenger
           file_contents
           .split(/\n{2,}/)
           .map! { |content| Rule.new(content) }
-          .reject! { |rule| invalid?(rule) }
+          .reject { |rule| invalid?(rule) }
           .sort!
       end
 


### PR DESCRIPTION
## About

I found a behavior that seems to be a bug and would like to correct it.

In some condition, the `#all_rules` might raise `NoMethodError`.

## Details

### Why?

> reject! は要素が 1 つ以上削除されれば self を、 1 つも削除されなければ nil を返します。

- https://docs.ruby-lang.org/ja/latest/method/Array/i/delete_if.html
- https://docs.ruby-lang.org/ja/latest/method/Enumerable/i/reject.html

### How to reproduce

I coudn't write test about this behavior, but let me share how to reproduce this:

Modify the example .rubocop_todo.yml:

```diff
diff --git a/spec/fixtures/.rubocop_todo.yml b/spec/fixtures/.rubocop_todo.yml
index 7977dc7..4b73d25 100644
--- a/spec/fixtures/.rubocop_todo.yml
+++ b/spec/fixtures/.rubocop_todo.yml
@@ -1,11 +1,3 @@
-# This configuration was generated by
-# `rubocop --auto-gen-config`
-# on 2018-10-14 13:25:00 +0900 using RuboCop version 0.59.2.
-# The point is for the user to remove these configuration records
-# one by one as the offenses are removed from the code base.
-# Note that changes in the inspected code, or installation of new
-# versions of RuboCop, may require this file to be generated again.
-
 # Offense count: 1
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: EnforcedStyle.
```

Then run rspec:

```
$ bundle exec rspec spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb:149
Run options: include {:locations=>{"./spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb"=>[149]}}

RubocopChallenger::Rubocop::TodoReader
  #any_rule
    returns a auto correctable rule at random (FAILED - 1)

Failures:

  1) RubocopChallenger::Rubocop::TodoReader#any_rule returns a auto correctable rule at random
     Failure/Error:
       file_contents
       .split(/\n{2,}/)
       .map! { |content| Rule.new(content) }
       .reject! { |rule| invalid?(rule) }
       .sort!
     
     NoMethodError:
       undefined method `sort!' for nil:NilClass
     # ./lib/rubocop_challenger/rubocop/todo_reader.rb:27:in `all_rules'
     # ./lib/rubocop_challenger/rubocop/todo_reader.rb:32:in `auto_correctable_rules'
     # ./lib/rubocop_challenger/rubocop/todo_reader.rb:47:in `any_rule'
     # ./spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb:150:in `block (3 levels) in <top (required)>'

Finished in 0.00117 seconds (files took 0.28482 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb:149 # RubocopChallenger::Rubocop::TodoReader#any_rule returns a auto correctable rule at random

Coverage report generated for RSpec to /home/r7kamura/ghq/github.com/r7kamura/rubocop_challenger/coverage. 229 / 386 LOC (59.33%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
```

### Other concerns

I found this while investigating another problem. The recent rubocop has `--no-offense-counts` option and it's enabled in my project, so rubocop_challenger doesn't work well there...
