### PR TITLE
Change `auto-correct` to `autocorrect`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ commands:
       - verify_rubocop_challenge
       - verify_rubocop_challenge
       - verify_rubocop_challenge
+      - rubocop
   rubocop_challenge:
     steps:
       - run:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![CircleCI](https://circleci.com/gh/ryz310/rubocop_challenger/tree/master.svg?style=svg&circle-token=cdf0ffce5b4c0c7804b50dde00ca5ef09cbadb67)](https://circleci.com/gh/ryz310/rubocop_challenger/tree/master) [![Gem Version](https://badge.fury.io/rb/rubocop_challenger.svg)](https://badge.fury.io/rb/rubocop_challenger) [![Maintainability](https://api.codeclimate.com/v1/badges/a18c1c17fc534bb32473/maintainability)](https://codeclimate.com/github/ryz310/rubocop_challenger/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/a18c1c17fc534bb32473/test_coverage)](https://codeclimate.com/github/ryz310/rubocop_challenger/test_coverage)
 
 If you introduce [`rubocop`](https://github.com/rubocop-hq/rubocop) to an existing Rails project later, you will use [`$ rubocop --auto-gen-config`](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#automatically-generated-configuration). But it will make a huge `.rubocop_todo.yml` and make you despair.
-On the other hand, `rubocop` has [`--auto-correct`](https://github.com/rubocop-hq/rubocop/blob/master/manual/basic_usage.md#other-useful-command-line-flags) option, it is possible to automatically repair the writing which does not conform to the rule. But since it occasionally destroys your code, it is quite dangerous to apply all at once.
+On the other hand, `rubocop` has [`--autocorrect`](https://github.com/rubocop-hq/rubocop/blob/master/manual/basic_usage.md#other-useful-command-line-flags) option, it is possible to automatically repair the writing which does not conform to the rule. But since it occasionally destroys your code, it is quite dangerous to apply all at once.
 It is ideal that to remove a disabled rule from `.rubocop_todo.yml` every day, to check whether it passes test, and can be obtained consent from the team. But it requires strong persistence and time.
 I call such work _Rubocop Challenge_. And the _RubocopChallenger_ is a gem to support this challenge!
 
 ## The history of RubocopChallenger with decrease of offense codes
 
-The following chart shows the history of RubocopChallenger and decrease of offense codes at a `.rubocop_todo.yml`. The project was released at 5 years ago, and then it was introduced the RuboCop gem for huge source code including a lots of offense codes. Before using the RubocopChallenger, it was not maintain to reduce offense codes. One day, I felt a crisis and started maintain with manual. I made a lots of Pull Requests to reduce them but it's a load for me and reviewers. So I created a script for automation the flow, which is the predecessor of Rubocop Challenger gem. It brought reducing the offense codes continuously. After 8 months, finally it has done. There is no auto-correctable offense codes.
-But there are many offenses which is un-auto-correctable yet. I will try to reduce it with the RubocopChallenger. The RubocopChallenger will
+The following chart shows the history of RubocopChallenger and decrease of offense codes at a `.rubocop_todo.yml`. The project was released at 5 years ago, and then it was introduced the RuboCop gem for huge source code including a lots of offense codes. Before using the RubocopChallenger, it was not maintain to reduce offense codes. One day, I felt a crisis and started maintain with manual. I made a lots of Pull Requests to reduce them but it's a load for me and reviewers. So I created a script for automation the flow, which is the predecessor of Rubocop Challenger gem. It brought reducing the offense codes continuously. After 8 months, finally it has done. There is no autocorrectable offense codes.
+But there are many offenses which is un-autocorrectable yet. I will try to reduce it with the RubocopChallenger. The RubocopChallenger will
 be continued to evolve.
 
 ![Decrease of offense codes](images/decrease_of_offense_codes.png)
@@ -18,7 +18,7 @@ be continued to evolve.
 ## Rubocop Challenge Flow
 
 1. Run _RubocopChallenger_ periodically from CI tool etc.
-1. When _RubocopChallenger_ starts, delete a disabled rule from `.rubocop_todo.yml` existing in your project, execute `$ rubocop --auto-correct` and create a PR which include modified results
+1. When _RubocopChallenger_ starts, delete a disabled rule from `.rubocop_todo.yml` existing in your project, execute `$ rubocop --autocorrect` and create a PR which include modified results
 1. You confirm the PR passes testing and then merge it if there is no problem
 
 [![Rubocop Challenge](images/rubocop_challenge.png)](https://github.com/ryz310/rubocop_challenger/pull/97)
@@ -88,7 +88,7 @@ See: [RuboCop Challenger を GitHub Actions で動かす](https://zenn.dev/yamat
 $ rubocop_challenger help
 
 Commands:
-  rubocop_challenger go --email=EMAIL --name=NAME  # Run `$ rubocop --auto-correct` and create a PR to GitHub repo
+  rubocop_challenger go --email=EMAIL --name=NAME  # Run `$ rubocop --autocorrect` and create a PR to GitHub repo
   rubocop_challenger help [COMMAND]                # Describe available commands or one specific command
   rubocop_challenger version                       # Show current version
 ```
@@ -122,10 +122,10 @@ Options:
                                                                  # Default: true
       [--offense-counts], [--no-offense-counts]                  # Include offense counts in .rubocop_todo.yml
                                                                  # Default: true
-      [--only-safe-auto-correct], [--no-only-safe-auto-correct]  # If given `true`, it executes `rubocop --auto-correct`,it means to correct safe cops only.
+      [--only-safe-autocorrect], [--no-only-safe-autocorrect]  # If given `true`, it executes `rubocop --autocorrect`,it means to correct safe cops only.
       [--verbose], [--no-verbose]                                # Displays executing command.
 
-Run `$ rubocop --auto-correct` and create a PR to GitHub repo
+Run `$ rubocop --autocorrect` and create a PR to GitHub repo
 ```
 
 ## Requirement

--- a/lib/rubocop_challenger/cli.rb
+++ b/lib/rubocop_challenger/cli.rb
@@ -5,7 +5,7 @@ require 'thor'
 module RubocopChallenger
   # To define CLI commands
   class CLI < Thor
-    desc 'go', 'Run `$ rubocop --auto-correct` and create a PR to GitHub repo'
+    desc 'go', 'Run `$ rubocop --autocorrect` and create a PR to GitHub repo'
     option :email,
            required: true,
            type: :string,
@@ -65,10 +65,10 @@ module RubocopChallenger
            type: :boolean,
            default: true,
            desc: 'Include offense counts in .rubocop_todo.yml'
-    option :only_safe_auto_correct,
+    option :only_safe_autocorrect,
            type: :boolean,
            default: false,
-           desc: 'If given `true`, it executes `rubocop --auto-correct`,' \
+           desc: 'If given `true`, it executes `rubocop --autocorrect`,' \
                  'it means to correct safe cops only.'
     option :verbose,
            type: :boolean,

--- a/lib/rubocop_challenger/errors.rb
+++ b/lib/rubocop_challenger/errors.rb
@@ -2,10 +2,10 @@
 
 module RubocopChallenger
   module Errors
-    # Raise if no auto-correctable rule in the `.rubocop_todo.yml`.
+    # Raise if no autocorrectable rule in the `.rubocop_todo.yml`.
     class NoAutoCorrectableRule < StandardError
       def initialize
-        super 'There is no auto-correctable rule'
+        super 'There is no autocorrectable rule'
       end
     end
   end

--- a/lib/rubocop_challenger/go.rb
+++ b/lib/rubocop_challenger/go.rb
@@ -11,8 +11,8 @@ module RubocopChallenger
     #   Include the date and time in .rubocop_todo.yml
     # @option offense_counts [Boolean]
     #   Include offense counts in .rubocop_todo.yml'
-    # @option only-safe-auto-correct [Boolean]
-    #   If given `true`, it executes `rubocop --auto-correct`,
+    # @option only-safe-autocorrect [Boolean]
+    #   If given `true`, it executes `rubocop --autocorrect`,
     #   it means to correct safe cops only.
     # @option name [String]
     #   The author name which use at the git commit
@@ -131,7 +131,7 @@ module RubocopChallenger
     end
 
     DESCRIPTION_THAT_CHALLENGE_IS_INCOMPLETE = <<~MSG
-      Rubocop Challenger has executed auto-correcting but it is incomplete.
+      Rubocop Challenger has executed autocorrecting but it is incomplete.
       Therefore the rule add to ignore list.
     MSG
 
@@ -141,7 +141,7 @@ module RubocopChallenger
     #
     # @param rule [Rubocop::Rule] The corrected rule
     def add_to_ignore_list_if_challenge_is_incomplete(rule)
-      return unless auto_correct_incomplete?(rule)
+      return unless autocorrect_incomplete?(rule)
 
       pull_request.commit! ':police_car: add the rule to the ignore list' do
         config_editor = Rubocop::ConfigEditor.new
@@ -156,7 +156,7 @@ module RubocopChallenger
     #
     # @param rule [Rubocop::Rule] The corrected rule
     # @return [Boolean] Return true if the challenge successed
-    def auto_correct_incomplete?(rule)
+    def autocorrect_incomplete?(rule)
       todo_reader = Rubocop::TodoReader.new(options[:file_path])
       todo_reader.all_rules.include?(rule)
     end
@@ -165,7 +165,7 @@ module RubocopChallenger
       {
         file_path: options[:file_path],
         mode: mode,
-        only_safe_auto_correct: options[:only_safe_auto_correct]
+        only_safe_autocorrect: options[:only_safe_autocorrect]
       }
     end
 

--- a/lib/rubocop_challenger/rubocop/challenge.rb
+++ b/lib/rubocop_challenger/rubocop/challenge.rb
@@ -4,17 +4,17 @@ module RubocopChallenger
   module Rubocop
     # To execute Rubocop Challenge flow
     class Challenge
-      def self.exec(file_path:, mode:, only_safe_auto_correct:)
-        new(file_path, mode, only_safe_auto_correct).send(:exec)
+      def self.exec(file_path:, mode:, only_safe_autocorrect:)
+        new(file_path, mode, only_safe_autocorrect).send(:exec)
       end
 
       private
 
-      attr_reader :mode, :only_safe_auto_correct, :command, :todo_reader, :todo_writer
+      attr_reader :mode, :only_safe_autocorrect, :command, :todo_reader, :todo_writer
 
-      def initialize(file_path, mode, only_safe_auto_correct)
+      def initialize(file_path, mode, only_safe_autocorrect)
         @mode = mode
-        @only_safe_auto_correct = only_safe_auto_correct
+        @only_safe_autocorrect = only_safe_autocorrect
         @command = Rubocop::Command.new
         @todo_reader = Rubocop::TodoReader.new(file_path)
         @todo_writer = Rubocop::TodoWriter.new(file_path)
@@ -24,7 +24,7 @@ module RubocopChallenger
       def exec
         verify_target_rule
         todo_writer.delete_rule(target_rule)
-        command.auto_correct(only_safe_auto_correct: only_safe_auto_correct)
+        command.autocorrect(only_safe_autocorrect: only_safe_autocorrect)
         target_rule
       end
 

--- a/lib/rubocop_challenger/rubocop/command.rb
+++ b/lib/rubocop_challenger/rubocop/command.rb
@@ -7,11 +7,11 @@ module RubocopChallenger
       include PrComet::CommandLine
 
       # Executes auto correction
-      def auto_correct(only_safe_auto_correct:)
-        if only_safe_auto_correct
-          run('--auto-correct')
+      def autocorrect(only_safe_autocorrect:)
+        if only_safe_autocorrect
+          run('--autocorrect')
         else
-          run('--auto-correct-all')
+          run('--autocorrect-all')
         end
       end
 

--- a/lib/rubocop_challenger/rubocop/command.rb
+++ b/lib/rubocop_challenger/rubocop/command.rb
@@ -9,9 +9,9 @@ module RubocopChallenger
       # Executes auto correction
       def autocorrect(only_safe_autocorrect:)
         if only_safe_autocorrect
-          run('--autocorrect')
+          run('-a') # --autocorrect     Autocorrect offenses (only when it's safe).
         else
-          run('--autocorrect-all')
+          run('-A') # --autocorrect-all Autocorrect offenses (safe and unsafe).
         end
       end
 

--- a/lib/rubocop_challenger/rubocop/rule.rb
+++ b/lib/rubocop_challenger/rubocop/rule.rb
@@ -26,9 +26,10 @@ module RubocopChallenger
         offense_count <=> other.offense_count
       end
 
-      def auto_correctable?
-        contents.include?('# Cop supports --auto-correct') || # for rubocop < v1.26.0
-          contents.match?(/# This cop supports (un)?safe auto-correction/) # for rubocop >= v1.26.0
+      def autocorrectable?
+        contents.match?('# This cop supports (un)?safe autocorrection') || # for rubocop >= v1.30.0
+          contents.match?(/# This cop supports (un)?safe auto-correction/) || # for rubocop >= v1.26.0
+          contents.include?('# Cop supports --auto-correct') # for rubocop < v1.26.0
       end
 
       def rubydoc_url

--- a/lib/rubocop_challenger/rubocop/todo_reader.rb
+++ b/lib/rubocop_challenger/rubocop/todo_reader.rb
@@ -29,23 +29,23 @@ module RubocopChallenger
       end
 
       # @return [Array<Rule>]
-      def auto_correctable_rules
-        all_rules.select(&:auto_correctable?)
+      def autocorrectable_rules
+        all_rules.select(&:autocorrectable?)
       end
 
       # @return [Rule]
       def least_occurrence_rule
-        auto_correctable_rules.first
+        autocorrectable_rules.first
       end
 
       # @return [Rule]
       def most_occurrence_rule
-        auto_correctable_rules.last
+        autocorrectable_rules.last
       end
 
       # @return [Rule]
       def any_rule
-        auto_correctable_rules.sample
+        autocorrectable_rules.sample
       end
 
       private

--- a/lib/rubocop_challenger/rubocop/yardoc.rb
+++ b/lib/rubocop_challenger/rubocop/yardoc.rb
@@ -18,8 +18,8 @@ module RubocopChallenger
         yardoc.tags('example').map { |tag| [tag.name, tag.text] }
       end
 
-      # Indicates whether the auto-correct a cop does is safe (equivalent) by design.
-      # If a cop is unsafe its auto-correct automatically becomes unsafe as well.
+      # Indicates whether the autocorrect a cop does is safe (equivalent) by design.
+      # If a cop is unsafe its autocorrect automatically becomes unsafe as well.
       #
       # @return [Boolean]
       def safe_autocorrect?

--- a/lib/templates/checklist.md.erb
+++ b/lib/templates/checklist.md.erb
@@ -4,10 +4,10 @@
 
 <% if safe_autocorrect? -%>
 **Safe autocorrect: Yes**
-:white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
+:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.
 <% else -%>
 **Safe autocorrect: No**
-:warning: The auto-correct a cop can yield false positives by design.
+:warning: The autocorrect a cop can yield false positives by design.
 <% end -%>
 
 ## Description

--- a/lib/templates/default.md.erb
+++ b/lib/templates/default.md.erb
@@ -4,10 +4,10 @@
 
 <% if safe_autocorrect? -%>
 **Safe autocorrect: Yes**
-:white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
+:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.
 <% else -%>
 **Safe autocorrect: No**
-:warning: The auto-correct a cop can yield false positives by design.
+:warning: The autocorrect a cop can yield false positives by design.
 <% end -%>
 
 ## Description

--- a/spec/fixtures/.expected_rubocop_todo.yml
+++ b/spec/fixtures/.expected_rubocop_todo.yml
@@ -9,35 +9,35 @@
 # Offense count: 4
 Style/Documentation:
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'lib/rubocop_challenger.rb'
-    - 'lib/rubocop_challenger/rubocop/rule.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_editor.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_reader.rb'
+    - "spec/**/*"
+    - "test/**/*"
+    - "lib/rubocop_challenger.rb"
+    - "lib/rubocop_challenger/rubocop/rule.rb"
+    - "lib/rubocop_challenger/rubocop/todo_editor.rb"
+    - "lib/rubocop_challenger/rubocop/todo_reader.rb"
 
 # Offense count: 2
-# This cop supports safe auto-correction (--auto-correct).
+# This cop supports safe autocorrection (--autocorrect).
 Style/ExpandPathArguments:
   Exclude:
-    - 'rubocop_challenger.gemspec'
+    - "rubocop_challenger.gemspec"
 
 # Offense count: 13
-# This cop supports safe auto-correction (--auto-correct).
+# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: when_needed, always, never
 Style/FrozenStringLiteralComment:
   Exclude:
-    - 'Gemfile'
-    - 'Rakefile'
-    - 'bin/console'
-    - 'rubocop_challenger.gemspec'
-    - 'lib/rubocop_challenger.rb'
-    - 'lib/rubocop_challenger/rubocop/rule.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_editor.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_reader.rb'
-    - 'lib/rubocop_challenger/version.rb'
-    - 'spec/rubocop_challenger/rubocop/rule_spec.rb'
-    - 'spec/rubocop_challenger_spec.rb'
-    - 'spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb'
-    - 'spec/spec_helper.rb'
+    - "Gemfile"
+    - "Rakefile"
+    - "bin/console"
+    - "rubocop_challenger.gemspec"
+    - "lib/rubocop_challenger.rb"
+    - "lib/rubocop_challenger/rubocop/rule.rb"
+    - "lib/rubocop_challenger/rubocop/todo_editor.rb"
+    - "lib/rubocop_challenger/rubocop/todo_reader.rb"
+    - "lib/rubocop_challenger/version.rb"
+    - "spec/rubocop_challenger/rubocop/rule_spec.rb"
+    - "spec/rubocop_challenger_spec.rb"
+    - "spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb"
+    - "spec/spec_helper.rb"

--- a/spec/fixtures/.rubocop_todo.yml
+++ b/spec/fixtures/.rubocop_todo.yml
@@ -7,45 +7,45 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# This cop supports safe auto-correction (--auto-correct).
+# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: empty_lines, no_empty_lines
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
-    - 'spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb'
+    - "spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb"
 
 # Offense count: 4
 Style/Documentation:
   Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'lib/rubocop_challenger.rb'
-    - 'lib/rubocop_challenger/rubocop/rule.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_editor.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_reader.rb'
+    - "spec/**/*"
+    - "test/**/*"
+    - "lib/rubocop_challenger.rb"
+    - "lib/rubocop_challenger/rubocop/rule.rb"
+    - "lib/rubocop_challenger/rubocop/todo_editor.rb"
+    - "lib/rubocop_challenger/rubocop/todo_reader.rb"
 
 # Offense count: 2
-# This cop supports safe auto-correction (--auto-correct).
+# This cop supports safe autocorrection (--autocorrect).
 Style/ExpandPathArguments:
   Exclude:
-    - 'rubocop_challenger.gemspec'
+    - "rubocop_challenger.gemspec"
 
 # Offense count: 13
-# This cop supports safe auto-correction (--auto-correct).
+# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: when_needed, always, never
 Style/FrozenStringLiteralComment:
   Exclude:
-    - 'Gemfile'
-    - 'Rakefile'
-    - 'bin/console'
-    - 'rubocop_challenger.gemspec'
-    - 'lib/rubocop_challenger.rb'
-    - 'lib/rubocop_challenger/rubocop/rule.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_editor.rb'
-    - 'lib/rubocop_challenger/rubocop/todo_reader.rb'
-    - 'lib/rubocop_challenger/version.rb'
-    - 'spec/rubocop_challenger/rubocop/rule_spec.rb'
-    - 'spec/rubocop_challenger_spec.rb'
-    - 'spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb'
-    - 'spec/spec_helper.rb'
+    - "Gemfile"
+    - "Rakefile"
+    - "bin/console"
+    - "rubocop_challenger.gemspec"
+    - "lib/rubocop_challenger.rb"
+    - "lib/rubocop_challenger/rubocop/rule.rb"
+    - "lib/rubocop_challenger/rubocop/todo_editor.rb"
+    - "lib/rubocop_challenger/rubocop/todo_reader.rb"
+    - "lib/rubocop_challenger/version.rb"
+    - "spec/rubocop_challenger/rubocop/rule_spec.rb"
+    - "spec/rubocop_challenger_spec.rb"
+    - "spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb"
+    - "spec/spec_helper.rb"

--- a/spec/lib/rubocop_challenger/cli_spec.rb
+++ b/spec/lib/rubocop_challenger/cli_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RubocopChallenger::CLI do
       end
 
       it 'outputs a description and exit process' do
-        expect { go }.to output(/There is no auto-correctable rule/).to_stdout
+        expect { go }.to output(/There is no autocorrectable rule/).to_stdout
       end
 
       it 'does not return exit code 1' do

--- a/spec/lib/rubocop_challenger/github/pr_template_spec.rb
+++ b/spec/lib/rubocop_challenger/github/pr_template_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RubocopChallenger::Github::PrTemplate do
 
     let(:rule) { RubocopChallenger::Rubocop::Rule.new(<<~CONTENTS) }
       # Offense count: 2
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       Style/Alias:
         Enabled: false
     CONTENTS
@@ -20,7 +20,7 @@ RSpec.describe RubocopChallenger::Github::PrTemplate do
         [Style/Alias](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Alias)
 
         **Safe autocorrect: Yes**
-        :white_check_mark: The auto-correct a cop does is safe (equivalent) by design.
+        :white_check_mark: The autocorrect a cop does is safe (equivalent) by design.
 
         ## Description
 

--- a/spec/lib/rubocop_challenger/go_spec.rb
+++ b/spec/lib/rubocop_challenger/go_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RubocopChallenger::Go do
       exclude_limit: 99,
       auto_gen_timestamp: false,
       offense_counts: offense_counts,
-      only_safe_auto_correct: false,
+      only_safe_autocorrect: false,
       verbose: false
     )
   end
@@ -141,7 +141,7 @@ RSpec.describe RubocopChallenger::Go do
           {
             file_path: '.rubocop_todo.yml',
             mode: 'most_occurrence',
-            only_safe_auto_correct: false
+            only_safe_autocorrect: false
           }
         end
 
@@ -159,7 +159,7 @@ RSpec.describe RubocopChallenger::Go do
           {
             file_path: '.rubocop_todo.yml',
             mode: 'random',
-            only_safe_auto_correct: false
+            only_safe_autocorrect: false
           }
         end
 
@@ -181,7 +181,7 @@ RSpec.describe RubocopChallenger::Go do
       end
     end
 
-    context 'when auto-correcting is incomplete' do
+    context 'when autocorrecting is incomplete' do
       before do
         allow(todo_reader).to receive(:all_rules).and_return([corrected_rule])
       end
@@ -207,7 +207,7 @@ RSpec.describe RubocopChallenger::Go do
           {
             file_path: '.rubocop_todo.yml',
             mode: 'most_occurrence',
-            only_safe_auto_correct: false
+            only_safe_autocorrect: false
           }
         end
 

--- a/spec/lib/rubocop_challenger/rubocop/challenge_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/challenge_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe RubocopChallenger::Rubocop::Challenge do
       described_class.exec(
         file_path: file_path,
         mode: mode,
-        only_safe_auto_correct: only_safe_auto_correct
+        only_safe_autocorrect: only_safe_autocorrect
       )
     end
 
     let(:file_path) { './spec/fixtures/.rubocop_todo.yml' }
     let(:mode) { 'least_occurrence' }
-    let(:only_safe_auto_correct) { false }
+    let(:only_safe_autocorrect) { false }
 
     let(:rule_instance) do
       instance_double(RubocopChallenger::Rubocop::Rule)
@@ -23,7 +23,7 @@ RSpec.describe RubocopChallenger::Rubocop::Challenge do
     let(:command_instance) do
       instance_double(
         RubocopChallenger::Rubocop::Command,
-        auto_correct: nil
+        autocorrect: nil
       )
     end
 
@@ -103,25 +103,25 @@ RSpec.describe RubocopChallenger::Rubocop::Challenge do
       end
     end
 
-    context 'with only_safe_auto_correct: true' do
-      let(:only_safe_auto_correct) { true }
+    context 'with only_safe_autocorrect: true' do
+      let(:only_safe_autocorrect) { true }
 
       it do
         rubocop_challenge_execute
         expect(command_instance)
-          .to have_received(:auto_correct)
-          .with(only_safe_auto_correct: true)
+          .to have_received(:autocorrect)
+          .with(only_safe_autocorrect: true)
       end
     end
 
-    context 'with only_safe_auto_correct: false' do
-      let(:only_safe_auto_correct) { false }
+    context 'with only_safe_autocorrect: false' do
+      let(:only_safe_autocorrect) { false }
 
       it do
         rubocop_challenge_execute
         expect(command_instance)
-          .to have_received(:auto_correct)
-          .with(only_safe_auto_correct: false)
+          .to have_received(:autocorrect)
+          .with(only_safe_autocorrect: false)
       end
     end
   end

--- a/spec/lib/rubocop_challenger/rubocop/command_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/command_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RubocopChallenger::Rubocop::Command do
         command.autocorrect(only_safe_autocorrect: true)
         expect(command)
           .to have_received(:execute)
-          .with('bundle exec rubocop --autocorrect || true')
+          .with('bundle exec rubocop -a || true')
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe RubocopChallenger::Rubocop::Command do
         command.autocorrect(only_safe_autocorrect: false)
         expect(command)
           .to have_received(:execute)
-          .with('bundle exec rubocop --autocorrect-all || true')
+          .with('bundle exec rubocop -A || true')
       end
     end
   end

--- a/spec/lib/rubocop_challenger/rubocop/command_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/command_spec.rb
@@ -7,22 +7,22 @@ RSpec.describe RubocopChallenger::Rubocop::Command do
 
   before { allow(command).to receive(:execute) }
 
-  describe '#auto_correct' do
-    context 'with only_safe_auto_correct: true' do
+  describe '#autocorrect' do
+    context 'with only_safe_autocorrect: true' do
       it do
-        command.auto_correct(only_safe_auto_correct: true)
+        command.autocorrect(only_safe_autocorrect: true)
         expect(command)
           .to have_received(:execute)
-          .with('bundle exec rubocop --auto-correct || true')
+          .with('bundle exec rubocop --autocorrect || true')
       end
     end
 
-    context 'with only_safe_auto_correct: false' do
+    context 'with only_safe_autocorrect: false' do
       it do
-        command.auto_correct(only_safe_auto_correct: false)
+        command.autocorrect(only_safe_autocorrect: false)
         expect(command)
           .to have_received(:execute)
-          .with('bundle exec rubocop --auto-correct-all || true')
+          .with('bundle exec rubocop --autocorrect-all || true')
       end
     end
   end

--- a/spec/lib/rubocop_challenger/rubocop/rule_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/rule_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
   describe '#offense_count' do
     let(:rule) { described_class.new(<<~CONTENTS) }
       # Offense count: 27
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
       # SupportedStyles: single_quotes, double_quotes
       Style/StringLiterals:
@@ -59,7 +59,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
 
     let(:rule) { described_class.new(<<~CONTENTS) }
       # Offense count: 2
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
       # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
       Style/HashSyntax:
@@ -70,7 +70,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule title is same to other one' do
       let(:other) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         Style/HashSyntax:
           Exclude:
             - 'rubocop_challenger.gemspec'
@@ -82,7 +82,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule title is different to other one' do
       let(:other) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         Layout/LeadingBlankLines:
           Exclude:
             - 'rubocop_challenger.gemspec'
@@ -97,7 +97,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
 
     let(:rule) { described_class.new(<<~CONTENTS) }
       # Offense count: 2
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
       # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
       Style/HashSyntax:
@@ -108,7 +108,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule offense count greater than other one' do
       let(:other) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         Layout/LeadingBlankLines:
           Exclude:
             - 'rubocop_challenger.gemspec'
@@ -120,7 +120,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule offense count is equal to other one' do
       let(:other) { described_class.new(<<~CONTENTS) }
         # Offense count: 2
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         Style/ExpandPathArguments:
           Exclude:
             - 'rubocop_challenger.gemspec'
@@ -143,46 +143,76 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     end
   end
 
-  describe '#auto_correctable?' do
-    subject { rule.auto_correctable? }
+  describe '#autocorrectable?' do
+    subject { rule.autocorrectable? }
 
-    context 'with auto-correction comment: Cop supports --auto-correct' do
-      let(:rule) { described_class.new(<<~CONTENTS) }
-        # Offense count: 1
-        # Cop supports --auto-correct.
-        Performance/StringReplacement:
-          Exclude:
-            - 'lib/rubocop_challenger.rb'
-      CONTENTS
+    describe 'rubocop v1.25.0' do
+      context 'with auto-correction comment: Cop supports --auto-correct' do
+        let(:rule) { described_class.new(<<~CONTENTS) }
+          # Offense count: 1
+          # Cop supports --auto-correct.
+          Performance/StringReplacement:
+            Exclude:
+              - 'lib/rubocop_challenger.rb'
+        CONTENTS
 
-      it { is_expected.to be_truthy }
+        it { is_expected.to be_truthy }
+      end
     end
 
-    context 'with auto-correction comment: This cop supports safe auto-correction' do
-      let(:rule) { described_class.new(<<~CONTENTS) }
-        # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
-        Performance/StringReplacement:
-          Exclude:
-            - 'lib/rubocop_challenger.rb'
-      CONTENTS
+    describe 'rubocop v1.26.0' do
+      context 'with auto-correction comment: This cop supports safe auto-correction' do
+        let(:rule) { described_class.new(<<~CONTENTS) }
+          # Offense count: 1
+          # This cop supports safe auto-correction (--auto-correct).
+          Performance/StringReplacement:
+            Exclude:
+              - 'lib/rubocop_challenger.rb'
+        CONTENTS
 
-      it { is_expected.to be_truthy }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with auto-correction comment: This cop supports unsafe auto-correction' do
+        let(:rule) { described_class.new(<<~CONTENTS) }
+          # Offense count: 1
+          # This cop supports unsafe auto-correction (--auto-correct-all).
+          Performance/StringReplacement:
+            Exclude:
+              - 'lib/rubocop_challenger.rb'
+        CONTENTS
+
+        it { is_expected.to be_truthy }
+      end
     end
 
-    context 'with auto-correction comment: This cop supports unsafe auto-correction' do
-      let(:rule) { described_class.new(<<~CONTENTS) }
-        # Offense count: 1
-        # This cop supports unsafe auto-correction (--auto-correct-all).
-        Performance/StringReplacement:
-          Exclude:
-            - 'lib/rubocop_challenger.rb'
-      CONTENTS
+    describe 'rubocop v1.30.0' do
+      context 'with autocorrection comment: This cop supports safe autocorrection' do
+        let(:rule) { described_class.new(<<~CONTENTS) }
+          # Offense count: 1
+          # This cop supports safe autocorrection (--autocorrect).
+          Performance/StringReplacement:
+            Exclude:
+              - 'lib/rubocop_challenger.rb'
+        CONTENTS
 
-      it { is_expected.to be_truthy }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with autocorrection comment: This cop supports unsafe autocorrection' do
+        let(:rule) { described_class.new(<<~CONTENTS) }
+          # Offense count: 1
+          # This cop supports unsafe autocorrection (--autocorrect-all).
+          Performance/StringReplacement:
+            Exclude:
+              - 'lib/rubocop_challenger.rb'
+        CONTENTS
+
+        it { is_expected.to be_truthy }
+      end
     end
 
-    context 'without auto-correction comment' do
+    context 'without autocorrection comment' do
       let(:rule) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
         Metrics/AbcSize:
@@ -197,7 +227,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule is included in the rubocop gem' do
       let(:rule) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         Style/RedundantSelf:
           Exclude:
             - 'lib/rubocop_challenger/rubocop/rule.rb'
@@ -212,7 +242,7 @@ RSpec.describe RubocopChallenger::Rubocop::Rule do
     context 'when the rule is included in the rubocop-rspec gem' do
       let(:rule) { described_class.new(<<~CONTENTS) }
         # Offense count: 1
-        # This cop supports safe auto-correction (--auto-correct).
+        # This cop supports safe autocorrection (--autocorrect).
         # Configuration parameters: CustomTransform, IgnoredWords.
         RSpec/ExampleWording:
           Exclude:

--- a/spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
   let(:autocorrectable_rule_which_offense_count_is_1) do
     RubocopChallenger::Rubocop::Rule.new(<<~CONTENTS)
       # Offense count: 1
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle.
       # SupportedStyles: empty_lines, no_empty_lines
       Layout/EmptyLinesAroundBlockBody:
@@ -20,7 +20,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
   let(:autocorrectable_rule_which_offense_count_is_2) do
     RubocopChallenger::Rubocop::Rule.new(<<~CONTENTS)
       # Offense count: 2
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       Style/ExpandPathArguments:
         Exclude:
           - 'rubocop_challenger.gemspec'
@@ -30,7 +30,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
   let(:autocorrectable_rule_which_offense_count_is_13) do
     RubocopChallenger::Rubocop::Rule.new(<<~CONTENTS)
       # Offense count: 13
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle.
       # SupportedStyles: when_needed, always, never
       Style/FrozenStringLiteralComment:
@@ -114,7 +114,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
     end
   end
 
-  describe '#auto_correctable_rules' do
+  describe '#autocorrectable_rules' do
     let(:rules_which_are_ordered_by_offense_count) do
       [
         autocorrectable_rule_which_offense_count_is_1,
@@ -123,14 +123,14 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
       ]
     end
 
-    it 'returns just auto correctable rules which ordered by offense count' do
-      expect(todo_reader.auto_correctable_rules)
+    it 'returns just autocorrectable rules which ordered by offense count' do
+      expect(todo_reader.autocorrectable_rules)
         .to eq rules_which_are_ordered_by_offense_count
     end
   end
 
   describe '#least_occurrence_rule' do
-    it 'returns a auto correctable rule with the least count of occurrences' do
+    it 'returns a autocorrectable rule with the least count of occurrences' do
       expect(todo_reader.least_occurrence_rule).to eq(
         autocorrectable_rule_which_offense_count_is_1
       )
@@ -138,7 +138,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
   end
 
   describe '#most_occurrence_rule' do
-    it 'returns a auto correctable rule with the most count of occurrences' do
+    it 'returns a autocorrectable rule with the most count of occurrences' do
       expect(todo_reader.most_occurrence_rule).to eq(
         autocorrectable_rule_which_offense_count_is_13
       )
@@ -146,7 +146,7 @@ RSpec.describe RubocopChallenger::Rubocop::TodoReader do
   end
 
   describe '#any_rule' do
-    it 'returns a auto correctable rule at random' do
+    it 'returns a autocorrectable rule at random' do
       expect(todo_reader.any_rule)
         .to eq(autocorrectable_rule_which_offense_count_is_1)
         .or eq(autocorrectable_rule_which_offense_count_is_2)

--- a/spec/lib/rubocop_challenger/rubocop/todo_writer_spec.rb
+++ b/spec/lib/rubocop_challenger/rubocop/todo_writer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe RubocopChallenger::Rubocop::TodoWriter do
     let(:expected) { File.read('spec/fixtures/.expected_rubocop_todo.yml') }
     let(:rule) { RubocopChallenger::Rubocop::Rule.new(<<~CONTENTS) }
       # Offense count: 1
-      # This cop supports safe auto-correction (--auto-correct).
+      # This cop supports safe autocorrection (--autocorrect).
       # Configuration parameters: EnforcedStyle.
       # SupportedStyles: empty_lines, no_empty_lines
       Layout/EmptyLinesAroundBlockBody:
         Exclude:
-          - 'spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb'
+          - "spec/lib/rubocop_challenger/rubocop/todo_reader_spec.rb"
     CONTENTS
 
     after do


### PR DESCRIPTION
On RuboCop v1.30.0 has changed "auto-correct" to "autocorrect". Rubocop Challenger also would like to follow suit.
And the `--auto-correct` (and `--auto-correct-all`) option is still available, but deprecated. The shorthands (`-a` and` -A`) are compatible before and after v1.30.0. So it will be migrated.

![スクリーンショット 2022-05-31 10 03 44](https://user-images.githubusercontent.com/3985540/171073350-95bff844-602e-4255-83a6-d38dc3f041fa.png)

Refs https://github.com/rubocop/rubocop/issues/10095
PR: https://github.com/rubocop/rubocop/pull/10547